### PR TITLE
Resolve Python 3 Unicode-objects must be encoded before hashing in UserFactory

### DIFF
--- a/django_libs/tests/factories.py
+++ b/django_libs/tests/factories.py
@@ -75,7 +75,9 @@ class UserFactory(factory.DjangoModelFactory):
     Password will be ``test123`` by default.
 
     """
-    username = factory.Sequence(lambda n: md5(str(n)).hexdigest()[0:30])
+    username = factory.Sequence(
+        lambda n: md5(str(n).encode('utf-8')).hexdigest()[0:30]
+    )
     email = factory.Sequence(lambda n: 'user{0}@example.com'.format(n))
 
     class Meta:


### PR DESCRIPTION
I know django-libs doesn't support Python 3 but this will continue to work with Python 2.

```
File "/home//user/.virtualenvs/django-testing/lib/python3.4/site-packages/django_libs/tests/factories.py", line 78, in <lambda>
    username = factory.Sequence(lambda n: md5(str(n)).hexdigest()[0:30])
nose.proxy.TypeError: Unicode-objects must be encoded before hashing
```