### PR TITLE
Adding cc and bcc to send email

### DIFF
--- a/django_libs/tests/utils/email_tests.py
+++ b/django_libs/tests/utils/email_tests.py
@@ -32,3 +32,18 @@ class SendEmailTestCase(TestCase):
                        'info@example.com', ['recipient@example.com'])
             self.assertEqual(Message.objects.count(), 1, msg=(
                 'An email should\'ve been sent'))
+
+    def test_cc_and_bcc(self):
+        send_email(
+            None,
+            {},
+            'subject.html',
+            'html_email.html',
+            'info@example.com',
+            ['recipient@example.com'],
+            cc=['cc@example.com'],
+            bcc=['bcc@example.com']
+        )
+        email = mail.outbox[0]
+        self.assertEqual(['cc@example.com'], email.cc)
+        self.assertEqual(['bcc@example.com'], email.bcc)

--- a/django_libs/utils/email.py
+++ b/django_libs/utils/email.py
@@ -40,11 +40,6 @@ def send_email(request, context, subject_template, body_template,
     headers = headers or {}
     if not reply_to:
         reply_to = from_email
-    if django.get_version() >= '1.8':
-        # The reply_to argument has been added in 1.8
-        reply_to = [reply_to]
-    else:
-        headers.update({'Reply-To': reply_to})
     if request and request.get_host():
         domain = request.get_host()
         protocol = 'https://' if request.is_secure() else 'http://'
@@ -68,19 +63,15 @@ def send_email(request, context, subject_template, body_template,
     else:
         subject = force_text(subject)
         message = force_text(message_plaintext)
-        kwargs = {
-            'subject': subject,
-            'body': message,
-            'from_email': from_email,
-            'to': recipients,
-            'cc': cc,
-            'bcc': bcc,
-            'headers': headers,
-        }
-        if django.get_version() >= '1.8':
-            # The reply_to argument has been added in 1.8
-            kwargs['reply_to'] = reply_to
-
-        email = EmailMultiAlternatives(**kwargs)
+        email = EmailMultiAlternatives(
+            subject=subject,
+            body=message,
+            from_email=from_email,
+            to=recipients,
+            cc=cc,
+            bcc=bcc,
+            headers=headers,
+            reply_to=[reply_to],
+        )
         email.attach_alternative(message_html, "text/html")
         email.send()


### PR DESCRIPTION
I added CC and BCC arguments to `utils.email.send_email`. 

I also removed the checks for Django<1.8 as the `send_email` function wasn't working for earlier versions anyway (due to the change of signature for `render_to_string`) and as Django 1.7 is unsuppored now there's no point in fixing things for it.